### PR TITLE
feat: add multi-window support (finally)

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -78,137 +78,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "7c02d123df017efcdfbd739ef81735b36c5ba83ec3c59c80a9d7ecc718f92e50"
 
 [[package]]
-name = "async-broadcast"
-version = "0.7.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "435a87a52755b8f27fcf321ac4f04b2802e337c8c4872923137471ec39c37532"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-channel"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "924ed96dd52d1b75e9c1a3e6275715fd320f5f9439fb5a4a11fa51f4221158d2"
-dependencies = [
- "concurrent-queue",
- "event-listener-strategy",
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-executor"
-version = "1.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c96bf972d85afc50bf5ab8fe2d54d1586b4e0b46c97c50a0c9e71e2f7bcd812a"
-dependencies = [
- "async-task",
- "concurrent-queue",
- "fastrand",
- "futures-lite",
- "pin-project-lite",
- "slab",
-]
-
-[[package]]
-name = "async-io"
-version = "2.6.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "456b8a8feb6f42d237746d4b3e9a178494627745c3c56c6ea55d92ba50d026fc"
-dependencies = [
- "autocfg",
- "cfg-if",
- "concurrent-queue",
- "futures-io",
- "futures-lite",
- "parking",
- "polling",
- "rustix",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-lock"
-version = "3.4.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "290f7f2596bd5b78a9fec8088ccd89180d7f9f55b94b0576823bbbdc72ee8311"
-dependencies = [
- "event-listener",
- "event-listener-strategy",
- "pin-project-lite",
-]
-
-[[package]]
-name = "async-process"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc50921ec0055cdd8a16de48773bfeec5c972598674347252c0399676be7da75"
-dependencies = [
- "async-channel",
- "async-io",
- "async-lock",
- "async-signal",
- "async-task",
- "blocking",
- "cfg-if",
- "event-listener",
- "futures-lite",
- "rustix",
-]
-
-[[package]]
-name = "async-recursion"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3b43422f69d8ff38f95f1b2bb76517c91589a924d1559a0e935d7c8ce0274c11"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
-name = "async-signal"
-version = "0.2.14"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "52b5aaafa020cf5053a01f2a60e8ff5dccf550f0f77ec54a4e47285ac2bab485"
-dependencies = [
- "async-io",
- "async-lock",
- "atomic-waker",
- "cfg-if",
- "futures-core",
- "futures-io",
- "rustix",
- "signal-hook-registry",
- "slab",
- "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "async-task"
-version = "4.7.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8b75356056920673b02621b35afd0f7dda9306d03c79a30f5c56c44cf256e3de"
-
-[[package]]
-name = "async-trait"
-version = "0.1.89"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9035ad2d096bed7955a320ee7e2230574d28fd3c3a0f186cbea1ff3c7eed5dbb"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "atk"
 version = "0.18.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -323,19 +192,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cdeb9d870516001442e364c5220d3574d2da8dc765554b4a617230d33fa58ef5"
 dependencies = [
  "objc2",
-]
-
-[[package]]
-name = "blocking"
-version = "1.6.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e83f8d02be6967315521be875afa792a316e28d57b5a2d401897e2a7921b7f21"
-dependencies = [
- "async-channel",
- "async-task",
- "futures-io",
- "futures-lite",
- "piper",
 ]
 
 [[package]]
@@ -559,15 +415,6 @@ checksum = "ba5a308b75df32fe02788e748662718f03fde005016435c444eea572398219fd"
 dependencies = [
  "bytes",
  "memchr",
-]
-
-[[package]]
-name = "concurrent-queue"
-version = "2.5.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4ca0197aee26d1ae37445ee532fefce43251d24cc7c166799f4d46817f1d3973"
-dependencies = [
- "crossbeam-utils",
 ]
 
 [[package]]
@@ -980,33 +827,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "endi"
-version = "1.1.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "66b7e2430c6dff6a955451e2cfc438f09cea1965a9d6f87f7e3b90decc014099"
-
-[[package]]
-name = "enumflags2"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "1027f7680c853e056ebcec683615fb6fbbc07dbaa13b4d5d9442b146ded4ecef"
-dependencies = [
- "enumflags2_derive",
- "serde",
-]
-
-[[package]]
-name = "enumflags2_derive"
-version = "0.7.12"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "67c78a4d8fdf9953a5c9d458f9efe940fd97a0cab0941c075a813ac594733827"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
-]
-
-[[package]]
 name = "equivalent"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1031,27 +851,6 @@ checksum = "39cab71617ae0d63f51a36d69f866391735b51691dbda63cf6f96d042b63efeb"
 dependencies = [
  "libc",
  "windows-sys 0.61.2",
-]
-
-[[package]]
-name = "event-listener"
-version = "5.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "e13b66accf52311f30a0db42147dadea9850cb48cd070028831ae5f5d4b856ab"
-dependencies = [
- "concurrent-queue",
- "parking",
- "pin-project-lite",
-]
-
-[[package]]
-name = "event-listener-strategy"
-version = "0.5.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "8be9f3dfaaffdae2972880079a491a1a8bb7cbed0b8dd7a347f668b4150a3b93"
-dependencies = [
- "event-listener",
- "pin-project-lite",
 ]
 
 [[package]]
@@ -1227,19 +1026,6 @@ name = "futures-io"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "cecba35d7ad927e23624b22ad55235f2239cfa44fd10428eecbeba6d6a717718"
-
-[[package]]
-name = "futures-lite"
-version = "2.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f78e10609fe0e0b3f4157ffab1876319b5b0db102a2c60dc4626306dc46b44ad"
-dependencies = [
- "fastrand",
- "futures-core",
- "futures-io",
- "parking",
- "pin-project-lite",
-]
 
 [[package]]
 name = "futures-macro"
@@ -1510,7 +1296,6 @@ dependencies = [
  "tauri-plugin-dialog",
  "tauri-plugin-os",
  "tauri-plugin-shell",
- "tauri-plugin-single-instance",
  "tauri-plugin-updater",
  "tauri-utils",
  "tempfile",
@@ -2645,12 +2430,6 @@ name = "heck"
 version = "0.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "2304e00983f87ffb38b55b444b5e3b60a884b5d30c0fca7d82fe33449bbe55ea"
-
-[[package]]
-name = "hermit-abi"
-version = "0.5.2"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fc0fef456e4baa96da950455cd02c081ca953b141298e41db3fc7e36b1da849c"
 
 [[package]]
 name = "hex"
@@ -3868,16 +3647,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "04744f49eae99ab78e0d5c0b603ab218f515ea8cfe5a456d7629ad883a3b6e7d"
 
 [[package]]
-name = "ordered-stream"
-version = "0.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9aa2b01e1d916879f73a53d01d1d6cee68adbb31d6d9177a8cfce093cced1d50"
-dependencies = [
- "futures-core",
- "pin-project-lite",
-]
-
-[[package]]
 name = "os_info"
 version = "3.14.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3941,12 +3710,6 @@ dependencies = [
  "libc",
  "system-deps",
 ]
-
-[[package]]
-name = "parking"
-version = "2.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f38d5652c16fde515bb1ecef450ab0f6a219d619a7274976324d5e377f7dceba"
 
 [[package]]
 name = "parking_lot"
@@ -4183,17 +3946,6 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "8b870d8c151b6f2fb93e84a13146138f05d02ed11c7e7c54f8826aaaf7c9f184"
 
 [[package]]
-name = "piper"
-version = "0.2.5"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "c835479a4443ded371d6c535cbfd8d31ad92c5d23ae9770a61bc155e4992a3c1"
-dependencies = [
- "atomic-waker",
- "fastrand",
- "futures-io",
-]
-
-[[package]]
 name = "pkg-config"
 version = "0.3.32"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -4229,20 +3981,6 @@ dependencies = [
  "fdeflate",
  "flate2",
  "miniz_oxide",
-]
-
-[[package]]
-name = "polling"
-version = "3.11.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5d0e4f59085d47d8241c88ead0f274e8a0cb551f3625263c05eb8dd897c34218"
-dependencies = [
- "cfg-if",
- "concurrent-queue",
- "hermit-abi",
- "pin-project-lite",
- "rustix",
- "windows-sys 0.61.2",
 ]
 
 [[package]]
@@ -5772,21 +5510,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "tauri-plugin-single-instance"
-version = "2.4.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "a33a5b7d78f0dec4406b003ea87c40bf928d801b6fd9323a556172c91d8712c1"
-dependencies = [
- "serde",
- "serde_json",
- "tauri",
- "thiserror 2.0.18",
- "tracing",
- "windows-sys 0.60.2",
- "zbus",
-]
-
-[[package]]
 name = "tauri-plugin-updater"
 version = "2.10.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -6243,19 +5966,7 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "63e71662fa4b2a2c3a26f570f037eb95bb1f85397f3cd8076caed2f026a6d100"
 dependencies = [
  "pin-project-lite",
- "tracing-attributes",
  "tracing-core",
-]
-
-[[package]]
-name = "tracing-attributes"
-version = "0.1.31"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "7490cfa5ec963746568740651ac6781f701c9c5ea257c58e057f3ba8cf69e8da"
-dependencies = [
- "proc-macro2",
- "quote",
- "syn 2.0.117",
 ]
 
 [[package]]
@@ -6306,17 +6017,6 @@ name = "typenum"
 version = "1.19.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "562d481066bde0658276a35467c4af00bdc6ee726305698a55b86e61d7ad82bb"
-
-[[package]]
-name = "uds_windows"
-version = "1.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f2f6fb2847f6742cd76af783a2a2c49e9375d0a111c7bef6f71cd9e738c72d6e"
-dependencies = [
- "memoffset",
- "tempfile",
- "windows-sys 0.61.2",
-]
 
 [[package]]
 name = "uluru"
@@ -7430,67 +7130,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "zbus"
-version = "5.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ca82f95dbd3943a40a53cfded6c2d0a2ca26192011846a1810c4256ef92c60bc"
-dependencies = [
- "async-broadcast",
- "async-executor",
- "async-io",
- "async-lock",
- "async-process",
- "async-recursion",
- "async-task",
- "async-trait",
- "blocking",
- "enumflags2",
- "event-listener",
- "futures-core",
- "futures-lite",
- "hex",
- "libc",
- "ordered-stream",
- "rustix",
- "serde",
- "serde_repr",
- "tracing",
- "uds_windows",
- "uuid",
- "windows-sys 0.61.2",
- "winnow 0.7.15",
- "zbus_macros",
- "zbus_names",
- "zvariant",
-]
-
-[[package]]
-name = "zbus_macros"
-version = "5.14.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "897e79616e84aac4b2c46e9132a4f63b93105d54fe8c0e8f6bffc21fa8d49222"
-dependencies = [
- "proc-macro-crate 3.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "zbus_names",
- "zvariant",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zbus_names"
-version = "4.3.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "ffd8af6d5b78619bab301ff3c560a5bd22426150253db278f164d6cf3b72c50f"
-dependencies = [
- "serde",
- "winnow 0.7.15",
- "zvariant",
-]
-
-[[package]]
 name = "zerocopy"
 version = "0.8.48"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -7593,43 +7232,3 @@ name = "zmij"
 version = "1.0.21"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "b8848ee67ecc8aedbaf3e4122217aff892639231befc6a1b58d29fff4c2cabaa"
-
-[[package]]
-name = "zvariant"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5708299b21903bbe348e94729f22c49c55d04720a004aa350f1f9c122fd2540b"
-dependencies = [
- "endi",
- "enumflags2",
- "serde",
- "winnow 0.7.15",
- "zvariant_derive",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_derive"
-version = "5.10.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "5b59b012ebe9c46656f9cc08d8da8b4c726510aef12559da3e5f1bf72780752c"
-dependencies = [
- "proc-macro-crate 3.5.0",
- "proc-macro2",
- "quote",
- "syn 2.0.117",
- "zvariant_utils",
-]
-
-[[package]]
-name = "zvariant_utils"
-version = "3.3.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "f75c23a64ef8f40f13a6989991e643554d9bef1d682a281160cf0c1bc389c5e9"
-dependencies = [
- "proc-macro2",
- "quote",
- "serde",
- "syn 2.0.117",
- "winnow 0.7.15",
-]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -21,7 +21,7 @@ tauri = { version = "2.0.0", features = [] }
 tauri-plugin-dialog = "2.0.0"
 tauri-plugin-os = "2.0.0"
 tauri-plugin-shell = "2"
-tauri-plugin-single-instance = "2"
+
 tauri-plugin-updater = "2.0.0"
 reqwest = { version = "0.13", features = ["blocking", "rustls"], default-features = false }
 url = "2"

--- a/src-tauri/src/commands/settings.rs
+++ b/src-tauri/src/commands/settings.rs
@@ -1,6 +1,6 @@
 use crate::git::types::{
     AvatarProviderMode, BackendMode, CommitDateMode, CommitPrimaryAction, ExternalDiffTool,
-    LinuxGraphicsMode, OperationResult, Settings, ThemeMode,
+    LinuxGraphicsMode, OperationResult, RepoOpenBehaviour, Settings, ThemeMode,
 };
 use crate::{AppState, configure_command, git_command};
 use reqwest::header::{ACCEPT, HeaderValue, RANGE};
@@ -9,9 +9,9 @@ use serde::Serialize;
 use std::path::Path;
 use std::time::Duration;
 use tauri::{Manager, ipc::Channel};
+use tauri_plugin_updater::{Update, UpdaterExt};
 #[cfg(windows)]
 use tauri_utils::{config::BundleType, platform};
-use tauri_plugin_updater::{Update, UpdaterExt};
 use url::Url;
 
 const GITHUB_UPDATE_ENDPOINT: &str =
@@ -95,9 +95,7 @@ async fn check_update_from_endpoint(
     if let Some(target) = current_updater_target() {
         updater = updater.target(target);
     }
-    let updater = updater
-        .build()
-        .map_err(|error| error.to_string())?;
+    let updater = updater.build().map_err(|error| error.to_string())?;
 
     updater.check().await.map_err(|error| error.to_string())
 }
@@ -200,6 +198,7 @@ pub fn set_theme_mode(
     for (_, window) in app.webview_windows() {
         let _ = window.set_background_color(Some(background_colour));
     }
+    crate::instance_coordinator::broadcast_settings_updated();
     settings
 }
 
@@ -335,6 +334,7 @@ pub fn get_global_file_mode() -> Result<Option<bool>, String> {
     }
 }
 
+#[cfg(windows)]
 fn diff_tool_key(tool: &ExternalDiffTool) -> Option<&'static str> {
     match tool {
         ExternalDiffTool::Meld => Some("meld"),
@@ -724,4 +724,16 @@ pub fn set_linux_graphics_mode(
     state: tauri::State<'_, AppState>,
 ) -> Settings {
     state.git_service.set_linux_graphics_mode(mode)
+}
+
+#[tauri::command]
+pub fn set_repo_open_behaviour(
+    repo_open_behaviour: RepoOpenBehaviour,
+    state: tauri::State<'_, AppState>,
+) -> Settings {
+    let settings = state
+        .git_service
+        .set_repo_open_behaviour(repo_open_behaviour);
+    crate::instance_coordinator::broadcast_settings_updated();
+    settings
 }

--- a/src-tauri/src/git/cli.rs
+++ b/src-tauri/src/git/cli.rs
@@ -1404,6 +1404,7 @@ impl CliGitHandler {
         if value.is_empty() { None } else { Some(value) }
     }
 
+    #[cfg(windows)]
     fn get_git_config_value(repo_path: &Path, key: &str) -> Option<String> {
         let mut command = crate::git_command();
         Self::configure_command(&mut command);

--- a/src-tauri/src/git/handler.rs
+++ b/src-tauri/src/git/handler.rs
@@ -281,6 +281,12 @@ impl GitService {
         })
     }
 
+    pub fn set_repo_open_behaviour(&self, behaviour: super::types::RepoOpenBehaviour) -> Settings {
+        self.update_settings(|settings| {
+            settings.repo_open_behaviour = behaviour;
+        })
+    }
+
     pub fn set_panel_layout(&self, left_pane_width: u32, right_pane_width: u32) -> Settings {
         self.update_settings(|settings| {
             settings.left_pane_width = left_pane_width;

--- a/src-tauri/src/git/types.rs
+++ b/src-tauri/src/git/types.rs
@@ -110,6 +110,19 @@ impl Default for LinuxGraphicsMode {
     }
 }
 
+#[derive(Debug, Clone, Copy, Serialize, Deserialize, PartialEq, Eq)]
+pub enum RepoOpenBehaviour {
+    Ask,
+    ExistingWindow,
+    NewWindow,
+}
+
+impl Default for RepoOpenBehaviour {
+    fn default() -> Self {
+        Self::Ask
+    }
+}
+
 #[derive(Debug, Clone, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
 pub struct Settings {
@@ -145,6 +158,8 @@ pub struct Settings {
     pub update_endpoint: String,
     #[serde(default)]
     pub linux_graphics_mode: LinuxGraphicsMode,
+    #[serde(default)]
+    pub repo_open_behaviour: RepoOpenBehaviour,
 }
 
 impl Default for Settings {
@@ -167,6 +182,7 @@ impl Default for Settings {
             auto_install_updates: false,
             update_endpoint: Self::default_update_endpoint(),
             linux_graphics_mode: LinuxGraphicsMode::Auto,
+            repo_open_behaviour: RepoOpenBehaviour::Ask,
         }
     }
 }

--- a/src-tauri/src/instance_coordinator.rs
+++ b/src-tauri/src/instance_coordinator.rs
@@ -1,0 +1,461 @@
+use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
+use std::io::{Read, Write};
+use std::net::{TcpListener, TcpStream};
+use std::sync::Mutex;
+use std::thread;
+use std::time::{Duration, SystemTime, UNIX_EPOCH};
+use tauri::{Emitter, Manager};
+
+const HEARTBEAT_SECS: u64 = 20;
+
+const STALE_SECS: u64 = 90;
+
+fn now_millis() -> u64 {
+    SystemTime::now()
+        .duration_since(UNIX_EPOCH)
+        .unwrap_or_default()
+        .as_millis() as u64
+}
+
+fn new_instance_id() -> String {
+    format!("{}-{}", std::process::id(), now_millis())
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct InstanceInfo {
+    pub instance_id: String,
+    pub pid: u32,
+    pub port: u16,
+    pub last_focused: u64,
+    pub started_at: u64,
+    pub sub_windows: Vec<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct InstanceRegistry {
+    instances: HashMap<String, InstanceInfo>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+#[serde(tag = "kind", content = "data", rename_all = "camelCase")]
+pub enum CoordinatorCommand {
+    OpenRepo { path: String },
+    OpenCloneWindow { destination: Option<String> },
+    FocusWindow { label: String },
+    SettingsUpdated,
+    Ping,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+struct CoordinatorReply {
+    ok: bool,
+    message: String,
+}
+
+#[derive(Debug, Clone)]
+struct CoordinatorHandle {
+    instance_id: String,
+    registry_path: std::path::PathBuf,
+    port: u16,
+}
+
+static COORDINATOR: std::sync::OnceLock<Mutex<CoordinatorHandle>> = std::sync::OnceLock::new();
+
+fn with_handle<F, R>(f: F) -> Result<R, String>
+where
+    F: FnOnce(&CoordinatorHandle) -> Result<R, String>,
+{
+    let guard = COORDINATOR
+        .get()
+        .ok_or_else(|| "Coordinator not initialised".to_string())?;
+    let handle = guard
+        .lock()
+        .map_err(|_| "Coordinator lock poisoned".to_string())?;
+    f(&handle)
+}
+
+fn read_registry(path: &std::path::Path) -> InstanceRegistry {
+    std::fs::read_to_string(path)
+        .ok()
+        .and_then(|t| serde_json::from_str::<InstanceRegistry>(&t).ok())
+        .unwrap_or(InstanceRegistry {
+            instances: HashMap::new(),
+        })
+}
+
+fn write_registry(path: &std::path::Path, reg: &InstanceRegistry) -> Result<(), String> {
+    let tmp = path.with_extension(format!("{}.tmp", std::process::id()));
+    let json = serde_json::to_string(reg).map_err(|e| e.to_string())?;
+    std::fs::write(&tmp, &json).map_err(|e| e.to_string())?;
+    std::fs::rename(&tmp, path).map_err(|e| e.to_string())?;
+    Ok(())
+}
+
+fn with_registry_lock<F, R>(path: &std::path::Path, f: F) -> Result<R, String>
+where
+    F: FnOnce() -> Result<R, String>,
+{
+    let lock_path = path.with_extension("lock");
+    let start = std::time::Instant::now();
+    loop {
+        match std::fs::OpenOptions::new()
+            .write(true)
+            .create_new(true)
+            .open(&lock_path)
+        {
+            Ok(_) => break,
+            Err(e) if e.kind() == std::io::ErrorKind::AlreadyExists => {
+                if start.elapsed() > Duration::from_secs(3) {
+                    let _ = std::fs::remove_file(&lock_path);
+                    continue;
+                }
+                thread::sleep(Duration::from_millis(25));
+            }
+            Err(e) => return Err(e.to_string()),
+        }
+    }
+
+    let result = f();
+    let _ = std::fs::remove_file(lock_path);
+    result
+}
+
+fn mutate_registry<F>(f: F)
+where
+    F: FnOnce(&mut InstanceRegistry),
+{
+    let path = match with_handle(|h| Ok(h.registry_path.clone())) {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let _ = with_registry_lock(&path, || {
+        let mut reg = read_registry(&path);
+        f(&mut reg);
+        write_registry(&path, &reg)
+    });
+}
+
+pub fn init(app_handle: &tauri::AppHandle) -> Result<(), String> {
+    let config_dir = app_handle
+        .path()
+        .app_config_dir()
+        .map_err(|e| format!("config dir: {e}"))?;
+    std::fs::create_dir_all(&config_dir).map_err(|e| format!("create config dir: {e}"))?;
+
+    let registry_path = config_dir.join("instance-registry.json");
+    let instance_id = new_instance_id();
+
+    let listener = TcpListener::bind("127.0.0.1:0").map_err(|e| format!("bind: {e}"))?;
+    listener
+        .set_nonblocking(true)
+        .map_err(|e| format!("nonblocking: {e}"))?;
+    let port = listener
+        .local_addr()
+        .map_err(|e| format!("local addr: {e}"))?
+        .port();
+
+    let handle = CoordinatorHandle {
+        instance_id: instance_id.clone(),
+        registry_path,
+        port,
+    };
+
+    COORDINATOR
+        .set(Mutex::new(handle.clone()))
+        .map_err(|_| "Already initialised".to_string())?;
+
+    register_self(&handle)?;
+
+    let app = app_handle.clone();
+    thread::spawn(move || accept_loop(listener, app));
+
+    let hb_handle = handle;
+    thread::spawn(move || heartbeat_loop(hb_handle));
+
+    prune_stale();
+
+    Ok(())
+}
+
+pub fn deregister() {
+    mutate_registry(|reg| {
+        if let Ok(handle) = with_handle(|h| Ok(h.instance_id.clone())) {
+            reg.instances.remove(&handle);
+            let our_pid = std::process::id();
+            reg.instances.retain(|_, info| info.pid != our_pid);
+        }
+    });
+}
+
+fn heartbeat_loop(handle: CoordinatorHandle) {
+    loop {
+        thread::sleep(Duration::from_secs(HEARTBEAT_SECS));
+        let _ = register_self(&handle);
+    }
+}
+
+fn register_self(handle: &CoordinatorHandle) -> Result<(), String> {
+    let now = now_millis();
+    let sub_windows = {
+        let reg = read_registry(&handle.registry_path);
+        reg.instances
+            .get(&handle.instance_id)
+            .map(|info| info.sub_windows.clone())
+            .unwrap_or_default()
+    };
+
+    mutate_registry(|reg| {
+        let is_new = !reg.instances.contains_key(&handle.instance_id);
+        let last_focused = reg
+            .instances
+            .get(&handle.instance_id)
+            .map(|info| info.last_focused)
+            .unwrap_or(now);
+
+        reg.instances.insert(
+            handle.instance_id.clone(),
+            InstanceInfo {
+                instance_id: handle.instance_id.clone(),
+                pid: std::process::id(),
+                port: handle.port,
+                last_focused: if is_new { now } else { last_focused },
+                started_at: if is_new {
+                    now
+                } else {
+                    reg.instances
+                        .get(&handle.instance_id)
+                        .map(|i| i.started_at)
+                        .unwrap_or(now)
+                },
+                sub_windows,
+            },
+        );
+    });
+    Ok(())
+}
+
+fn prune_stale() {
+    let cutoff = now_millis().saturating_sub(STALE_SECS * 1000);
+    mutate_registry(|reg| {
+        reg.instances
+            .retain(|_, info| info.last_focused >= cutoff || info.started_at >= cutoff);
+    });
+}
+
+fn accept_loop(listener: TcpListener, app_handle: tauri::AppHandle) {
+    loop {
+        match listener.accept() {
+            Ok((stream, _)) => {
+                let app = app_handle.clone();
+                thread::spawn(move || handle_connection(stream, app));
+            }
+            Err(ref e) if e.kind() == std::io::ErrorKind::WouldBlock => {
+                thread::sleep(Duration::from_millis(150));
+            }
+            Err(_) => {
+                thread::sleep(Duration::from_millis(500));
+            }
+        }
+    }
+}
+
+fn handle_connection(mut stream: TcpStream, app: tauri::AppHandle) {
+    let mut buf = [0u8; 8192];
+    let n = match stream.read(&mut buf) {
+        Ok(n) if n > 0 => n,
+        _ => return,
+    };
+
+    let raw = String::from_utf8_lossy(&buf[..n]);
+    let body = raw
+        .find("\r\n\r\n")
+        .map(|idx| raw[idx + 4..].trim().to_string())
+        .unwrap_or_default();
+
+    let cmd: CoordinatorCommand = match serde_json::from_str(&body) {
+        Ok(c) => c,
+        Err(e) => {
+            respond(&mut stream, 400, &format!("Bad JSON: {e}"));
+            return;
+        }
+    };
+
+    let (ok, msg) = process_command(cmd, &app);
+    respond(&mut stream, if ok { 200 } else { 500 }, &msg);
+}
+
+fn process_command(cmd: CoordinatorCommand, app: &tauri::AppHandle) -> (bool, String) {
+    match cmd {
+        CoordinatorCommand::OpenRepo { path } => {
+            let _ = app.emit("instance-open-repo", path.clone());
+            (true, path)
+        }
+        CoordinatorCommand::OpenCloneWindow { destination } => {
+            if let Some(path) = destination.clone() {
+                if let Some(state) = app.try_state::<crate::PendingCloneDestination>() {
+                    if let Ok(mut guard) = state.0.lock() {
+                        *guard = Some(path.clone());
+                    }
+                }
+                let _ = app.emit("clone-destination-updated", path);
+            }
+            if let Some(w) = app.get_webview_window("clone-repository") {
+                let _ = w.show();
+                let _ = w.set_focus();
+                (true, "focused".into())
+            } else {
+                (false, "clone window not found".into())
+            }
+        }
+        CoordinatorCommand::FocusWindow { label } => {
+            if let Some(w) = app.get_webview_window(&label) {
+                let _ = w.show();
+                let _ = w.set_focus();
+                (true, "focused".into())
+            } else {
+                (false, "window not found".into())
+            }
+        }
+        CoordinatorCommand::SettingsUpdated => {
+            let _ = app.emit("instance-settings-updated", ());
+            (true, "ok".into())
+        }
+        CoordinatorCommand::Ping => (true, "pong".into()),
+    }
+}
+
+fn respond(stream: &mut TcpStream, status: u16, msg: &str) {
+    let reason = if status == 200 {
+        "OK"
+    } else if status == 400 {
+        "Bad Request"
+    } else {
+        "Internal Server Error"
+    };
+    let body = serde_json::to_string(&CoordinatorReply {
+        ok: status == 200,
+        message: msg.to_string(),
+    })
+    .unwrap_or_else(|_| "{\"ok\":false,\"message\":\"response serialisation failed\"}".to_string());
+    let _ = stream.write_all(
+        format!(
+            "HTTP/1.1 {status} {reason}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{body}",
+            body.len()
+        )
+        .as_bytes(),
+    );
+}
+
+pub fn notify_focused() {
+    mutate_registry(|reg| {
+        let own_id = with_handle(|h| Ok(h.instance_id.clone())).unwrap_or_default();
+        if let Some(info) = reg.instances.get_mut(&own_id) {
+            info.last_focused = now_millis();
+        }
+    });
+}
+
+pub fn register_sub_window(label: &str) {
+    mutate_registry(|reg| {
+        let own_id = with_handle(|h| Ok(h.instance_id.clone())).unwrap_or_default();
+        if let Some(info) = reg.instances.get_mut(&own_id) {
+            if !info.sub_windows.contains(&label.to_string()) {
+                info.sub_windows.push(label.to_string());
+            }
+        }
+    });
+}
+
+pub fn unregister_sub_window(label: &str) {
+    mutate_registry(|reg| {
+        let own_id = with_handle(|h| Ok(h.instance_id.clone())).unwrap_or_default();
+        if let Some(info) = reg.instances.get_mut(&own_id) {
+            info.sub_windows.retain(|w| w != label);
+        }
+    });
+}
+
+pub fn find_sub_window_owner(label: &str) -> Option<InstanceInfo> {
+    let path = with_handle(|h| Ok(h.registry_path.clone())).ok()?;
+    let reg = read_registry(&path);
+    let cutoff = now_millis().saturating_sub(STALE_SECS * 1000);
+
+    for info in reg.instances.values() {
+        if info.sub_windows.contains(&label.to_string()) && info.last_focused >= cutoff {
+            return Some(info.clone());
+        }
+    }
+    None
+}
+
+pub fn send_command(target_port: u16, cmd: &CoordinatorCommand) -> Result<(), String> {
+    let json = serde_json::to_string(cmd).map_err(|e| e.to_string())?;
+    let req = format!(
+        "POST / HTTP/1.1\r\nHost: 127.0.0.1:{}\r\nContent-Type: application/json\r\nContent-Length: {}\r\nConnection: close\r\n\r\n{}",
+        target_port,
+        json.len(),
+        json,
+    );
+
+    let mut stream = TcpStream::connect_timeout(
+        &format!("127.0.0.1:{target_port}")
+            .parse()
+            .map_err(|e: std::net::AddrParseError| e.to_string())?,
+        Duration::from_secs(2),
+    )
+    .map_err(|e| e.to_string())?;
+    stream.set_read_timeout(Some(Duration::from_secs(2))).ok();
+    stream.set_write_timeout(Some(Duration::from_secs(2))).ok();
+    stream
+        .write_all(req.as_bytes())
+        .map_err(|e| e.to_string())?;
+
+    let mut buf = [0u8; 2048];
+    let n = stream.read(&mut buf).map_err(|e| e.to_string())?;
+    let raw = String::from_utf8_lossy(&buf[..n]);
+    let status_ok = raw.starts_with("HTTP/1.1 200");
+    let body = raw
+        .find("\r\n\r\n")
+        .map(|idx| raw[idx + 4..].trim())
+        .unwrap_or_default();
+    let reply = serde_json::from_str::<CoordinatorReply>(body).ok();
+    if status_ok && reply.as_ref().is_none_or(|r| r.ok) {
+        Ok(())
+    } else {
+        Err(reply
+            .map(|r| r.message)
+            .filter(|message| !message.is_empty())
+            .unwrap_or_else(|| "Coordinator command failed".to_string()))
+    }
+}
+
+pub fn broadcast_settings_updated() {
+    let path = match with_handle(|h| Ok(h.registry_path.clone())) {
+        Ok(p) => p,
+        Err(_) => return,
+    };
+    let own_id = match with_handle(|h| Ok(h.instance_id.clone())) {
+        Ok(id) => id,
+        Err(_) => return,
+    };
+    let cutoff = now_millis().saturating_sub(STALE_SECS * 1000);
+    let reg = read_registry(&path);
+
+    for (id, info) in &reg.instances {
+        if *id == own_id || info.last_focused < cutoff {
+            continue;
+        }
+        let _ = send_command(info.port, &CoordinatorCommand::SettingsUpdated);
+    }
+}
+
+pub fn spawn_new_instance_open_repo(path: &str) -> Result<(), String> {
+    let exe = std::env::current_exe().map_err(|e| format!("exe path: {e}"))?;
+    std::process::Command::new(exe)
+        .arg("--open")
+        .arg(path)
+        .spawn()
+        .map_err(|e| format!("spawn: {e}"))?;
+    Ok(())
+}

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,6 +1,7 @@
 mod avatar;
 pub mod commands;
 pub mod git;
+mod instance_coordinator;
 pub mod shell;
 mod window_manager;
 
@@ -8,9 +9,9 @@ use git::handler::GitService;
 use git::types::AvatarProviderMode;
 use notify::{RecommendedWatcher, RecursiveMode, Watcher};
 use serde::Serialize;
+use shell::cli::ShellStartupAction;
 use std::sync::{Arc, Mutex, OnceLock, atomic::AtomicBool};
 use tauri::{Emitter, Manager};
-use shell::cli::ShellStartupAction;
 
 pub struct AppState {
     pub git_service: GitService,
@@ -22,6 +23,8 @@ pub struct CloneCancelFlag(pub Arc<AtomicBool>);
 struct FsWatcherState(Mutex<Option<RecommendedWatcher>>);
 
 struct StartupState(Mutex<Option<ShellStartupAction>>);
+
+pub(crate) struct PendingCloneDestination(Mutex<Option<String>>);
 
 #[cfg(windows)]
 const CREATE_NO_WINDOW: u32 = 0x08000000;
@@ -496,6 +499,74 @@ fn get_startup_action(state: tauri::State<'_, StartupState>) -> Option<ShellStar
     state.0.lock().ok().and_then(|mut g| g.take())
 }
 
+#[tauri::command]
+fn take_pending_clone_destination(
+    state: tauri::State<'_, PendingCloneDestination>,
+) -> Option<String> {
+    state.0.lock().ok().and_then(|mut g| g.take())
+}
+
+#[tauri::command]
+fn open_repo_in_new_window(path: String) -> Result<(), String> {
+    instance_coordinator::spawn_new_instance_open_repo(&path)
+}
+
+#[tauri::command]
+async fn open_clone_window(
+    destination: Option<String>,
+    app: tauri::AppHandle,
+    state: tauri::State<'_, AppState>,
+    pending: tauri::State<'_, PendingCloneDestination>,
+) -> Result<(), String> {
+    if let Some(existing) = app.get_webview_window("clone-repository") {
+        if let Some(path) = destination {
+            let mut guard = pending
+                .0
+                .lock()
+                .map_err(|_| "Internal clone destination state error".to_string())?;
+            *guard = Some(path.clone());
+            let _ = app.emit("clone-destination-updated", path);
+        }
+        let _ = existing.show();
+        let _ = existing.set_focus();
+        return Ok(());
+    }
+
+    if let Some(owner) = instance_coordinator::find_sub_window_owner("clone-repository") {
+        if instance_coordinator::send_command(
+            owner.port,
+            &instance_coordinator::CoordinatorCommand::OpenCloneWindow {
+                destination: destination.clone(),
+            },
+        )
+        .is_ok()
+        {
+            return Ok(());
+        }
+    }
+
+    if let Some(path) = destination {
+        let mut guard = pending
+            .0
+            .lock()
+            .map_err(|_| "Internal clone destination state error".to_string())?;
+        *guard = Some(path);
+    }
+
+    window_manager::open_sub_window(
+        app,
+        "clone-repository".to_string(),
+        "Clone Repository".to_string(),
+        "clone.html".to_string(),
+        520.0,
+        460.0,
+        false,
+        false,
+        state,
+    )
+    .await
+}
+
 pub fn run() {
     #[cfg(target_os = "linux")]
     sanitize_linux_xdg_env();
@@ -506,14 +577,6 @@ pub fn run() {
     let startup_action = shell::cli::parse_shell_action(&std::env::args().collect::<Vec<String>>());
 
     let builder = tauri::Builder::default()
-        .plugin(tauri_plugin_single_instance::init(|app, args, _cwd| {
-            if let Some(action) = shell::cli::parse_shell_action(&args) {
-                let _ = app.emit("shell-action", action);
-            }
-            if let Some(window) = app.get_webview_window("main") {
-                let _ = window.set_focus();
-            }
-        }))
         .plugin(tauri_plugin_shell::init())
         .plugin(tauri_plugin_dialog::init())
         .plugin(tauri_plugin_os::init())
@@ -527,6 +590,7 @@ pub fn run() {
         .manage(CloneCancelFlag(Arc::new(AtomicBool::new(false))))
         .manage(FsWatcherState(Mutex::new(None)))
         .manage(StartupState(Mutex::new(startup_action)))
+        .manage(PendingCloneDestination(Mutex::new(None)))
         .setup(|app| {
             #[cfg(desktop)]
             app.handle()
@@ -559,7 +623,22 @@ pub fn run() {
                     .set_try_platform_first(settings.try_platform_first);
             }
 
+            instance_coordinator::init(&app.handle())?;
+
             Ok(())
+        })
+        .on_window_event(|window, event| {
+            if window.label() == "main" {
+                if let tauri::WindowEvent::Focused(true) = event {
+                    instance_coordinator::notify_focused();
+                }
+                if let tauri::WindowEvent::Destroyed = event {
+                    instance_coordinator::deregister();
+                }
+            }
+            if let tauri::WindowEvent::Destroyed = event {
+                instance_coordinator::unregister_sub_window(window.label().as_ref());
+            }
         });
 
     builder
@@ -594,6 +673,7 @@ pub fn run() {
             commands::settings::set_auto_install_updates,
             commands::settings::set_update_endpoint,
             commands::settings::set_linux_graphics_mode,
+            commands::settings::set_repo_open_behaviour,
             commands::history::get_commit_history,
             commands::history::verify_commits,
             commands::history::merge_branch,
@@ -676,6 +756,9 @@ pub fn run() {
             window_manager::show_window,
             window_manager::get_system_theme_hint,
             get_startup_action,
+            open_clone_window,
+            open_repo_in_new_window,
+            take_pending_clone_destination,
             get_windows_git_runtime_status,
             install_git_with_winget,
         ])

--- a/src-tauri/src/window_manager.rs
+++ b/src-tauri/src/window_manager.rs
@@ -161,6 +161,19 @@ pub async fn open_sub_window(
         return Ok(());
     }
 
+    if let Some(owner) = crate::instance_coordinator::find_sub_window_owner(&label) {
+        if crate::instance_coordinator::send_command(
+            owner.port,
+            &crate::instance_coordinator::CoordinatorCommand::FocusWindow {
+                label: label.clone(),
+            },
+        )
+        .is_ok()
+        {
+            return Ok(());
+        }
+    }
+
     let mut builder =
         tauri::WebviewWindowBuilder::new(&app, &label, tauri::WebviewUrl::App(path.clone().into()))
             .title(title)
@@ -201,6 +214,7 @@ pub async fn open_sub_window(
 
     let _window = builder.build().map_err(|e| e.to_string())?;
 
+    crate::instance_coordinator::register_sub_window(&label);
     // WebView2 on Windows can fail to navigate when the window is created
     // from the backend - the WebView2 controller initialises asynchronously
     // and the initial URL set via WebviewUrl::App may be lost. Eval calls

--- a/src/api/commands.ts
+++ b/src/api/commands.ts
@@ -38,6 +38,7 @@ import type {
     RemoteInfo,
     RepoRequest,
     RepoStatus,
+    RepoOpenBehaviour,
     SetBranchUpstreamRequest,
     Settings,
     StageFilesRequest,
@@ -404,6 +405,10 @@ export function setUpdateEndpoint(updateEndpoint: string): Promise<Settings> {
     return invoke<Settings>("set_update_endpoint", {updateEndpoint});
 }
 
+export function setRepoOpenBehaviour(repoOpenBehaviour: RepoOpenBehaviour): Promise<Settings> {
+    return invoke<Settings>("set_repo_open_behaviour", {repoOpenBehaviour});
+}
+
 export function getConfigFilePath(): Promise<string | null> {
     return invoke<string | null>("get_config_file_path");
 }
@@ -499,15 +504,7 @@ export function openSettingsWindow(): Promise<void> {
 }
 
 export function openCloneWindow(): Promise<void> {
-    return invoke("open_sub_window", {
-        label: "clone-repository",
-        path: "clone.html",
-        title: "Clone Repository",
-        width: 520,
-        height: 460,
-        resizable: false,
-        showImmediately: false,
-    });
+    return invoke("open_clone_window", {destination: null});
 }
 
 export function openAboutWindow(): Promise<void> {
@@ -548,6 +545,18 @@ export function openResultLogWindow(): Promise<void> {
 
 export function getStartupAction(): Promise<ShellStartupAction | null> {
     return invoke<ShellStartupAction | null>("get_startup_action");
+}
+
+export function openRepoInNewWindow(path: string): Promise<void> {
+    return invoke("open_repo_in_new_window", {path});
+}
+
+export function openCloneWindowWithDestination(destination?: string): Promise<void> {
+    return invoke("open_clone_window", {destination: destination ?? null});
+}
+
+export function takePendingCloneDestination(): Promise<string | null> {
+    return invoke<string | null>("take_pending_clone_destination");
 }
 
 export function getWindowsGitRuntimeStatus(): Promise<WindowsGitRuntimeStatus> {

--- a/src/components/App.tsx
+++ b/src/components/App.tsx
@@ -10,11 +10,10 @@ import {useToast} from "../hooks/useToast";
 import {useUpdateFlow} from "../hooks/useUpdateFlow";
 import {usePlatform} from "../hooks/usePlatform";
 import * as api from "../api/commands";
-import type {AvailableUpdate, Settings, ShellStartupAction, ThemeMode} from "../types";
-import {appendResultLog} from "../utils/resultLog";
+import type {AvailableUpdate, RepoOpenBehaviour, Settings, ShellStartupAction, ThemeMode} from "../types";
+import {appendResultLog, setResultLogRepoPath} from "../utils/resultLog";
 import "./App.css";
 
-const REPO_STORAGE_KEY = "gitmun.activeRepoPath";
 const BACKEND_MODE_KEY = "gitmun.backendMode";
 const SHOW_RESULT_LOG_KEY = "gitmun.showResultLog";
 const THEME_MODE_KEY = "gitmun.themeMode";
@@ -271,7 +270,7 @@ export function App() {
                     setRepoPath(path);
                     pushRecentRepo(path);
                     showToast(`Opened ${path.split("/").pop()}`);
-                    appendResultLog("info", `Opened repository ${path}`, "unknown");
+                    appendResultLog("info", `Opened repository ${path}`, "unknown", path);
                 }).catch((e: unknown) => showToast(String(e), "error"));
             });
             if (cancelled) fn(); else unlisten = fn;
@@ -288,7 +287,7 @@ export function App() {
                 setRepoPath(action.path);
                 pushRecentRepo(action.path);
                 showToast(`Opened ${action.path.split("/").pop()}`);
-                appendResultLog("info", `Opened repository ${action.path} from shell`, "unknown");
+                appendResultLog("info", `Opened repository ${action.path} from shell`, "unknown", action.path);
             }).catch(async (e: unknown) => {
                 if (isLikelyNotRepoError(e)) {
                     const confirmed = await ask(
@@ -301,15 +300,14 @@ export function App() {
                         setRepoPath(action.path);
                         pushRecentRepo(action.path);
                         showToast("Repository initialised", "success");
-                        appendResultLog("success", result.message, result.backendUsed);
+                        appendResultLog("success", result.message, result.backendUsed, action.path);
                     }
                 } else {
                     showToast(String(e), "error");
                 }
             });
         } else if (action.action === "cloneHere") {
-            localStorage.setItem("gitmun.pendingCloneDestination", action.path);
-            api.openCloneWindow().catch(e => {
+            api.openCloneWindowWithDestination(action.path).catch(e => {
                 showToast(String(e), "error");
                 appendResultLog("error", `Clone window failed to open: ${String(e)}`, "unknown");
             });
@@ -399,8 +397,10 @@ export function App() {
         let cancelled = false;
         let unlisten: (() => void) | null = null;
         (async () => {
-            const fn = await listen<ShellStartupAction>("shell-action", (event) => {
-                handleShellAction(event.payload);
+            const fn = await listen<string>("instance-open-repo", (event) => {
+                const path = event.payload;
+                if (!path) return;
+                handleShellAction({action: "openRepo", path});
             });
             if (cancelled) fn(); else unlisten = fn;
         })();
@@ -443,6 +443,38 @@ export function App() {
             unlisten?.();
         };
     }, [showToast]);
+
+    useEffect(() => {
+        let cancelled = false;
+        let unlisten: (() => void) | null = null;
+        (async () => {
+            const fn = await listen("instance-settings-updated", async () => {
+                const settings = await api.getSettings();
+                document.documentElement.dataset.theme = await resolveTheme(settings.themeMode);
+                localStorage.setItem(BACKEND_MODE_KEY, settings.backendMode);
+                localStorage.setItem(SHOW_RESULT_LOG_KEY, String(settings.showResultLog));
+                localStorage.setItem(THEME_MODE_KEY, settings.themeMode);
+                const totalWidth = appBodyRef.current?.getBoundingClientRect().width ?? 0;
+                const desiredLeft = isValidPaneWidth(settings.leftPaneWidth)
+                    ? settings.leftPaneWidth : paneLayoutRef.current.left;
+                const desiredRight = isValidPaneWidth(settings.rightPaneWidth)
+                    ? settings.rightPaneWidth : paneLayoutRef.current.right;
+                const nextLayout = totalWidth > 0
+                    ? clampPaneLayout(totalWidth, desiredLeft, desiredRight)
+                    : {left: desiredLeft, right: desiredRight};
+                setLeftPaneWidth(nextLayout.left);
+                setRightPaneWidth(nextLayout.right);
+                paneLayoutRef.current = nextLayout;
+                if (totalWidth > 0) savePaneRatios(totalWidth, nextLayout.left, nextLayout.right);
+                setSettingsRevision(r => r + 1);
+            });
+            if (cancelled) fn(); else unlisten = fn;
+        })();
+        return () => {
+            cancelled = true;
+            unlisten?.();
+        };
+    }, []);
 
     useEffect(() => {
         let cancelled = false;
@@ -506,24 +538,8 @@ export function App() {
     }, [draggingPane, leftPaneCollapsed]);
 
     useEffect(() => {
-        const stored = localStorage.getItem(REPO_STORAGE_KEY);
-        if (!stored) {
-            setReady(true);
-            return;
-        }
-        api.validateRepoPath(stored).then(() => {
-            setRepoPath(stored);
-            setReady(true);
-        }).catch(() => {
-            localStorage.removeItem(REPO_STORAGE_KEY);
-            setRecentRepos(prev => {
-                const next = prev.filter(p => p !== stored);
-                localStorage.setItem("gitmun.recentRepos", JSON.stringify(next));
-                return next;
-            });
-            setReady(true);
-        });
-        // eslint-disable-next-line react-hooks/exhaustive-deps
+        // Plain launches start empty; shell actions handle explicit opens.
+        setReady(true);
     }, []);
 
     useEffect(() => {
@@ -533,8 +549,8 @@ export function App() {
     }, [ready]);
 
     useEffect(() => {
+        setResultLogRepoPath(repoPath);
         if (repoPath) {
-            localStorage.setItem(REPO_STORAGE_KEY, repoPath);
             const repoName = repoPath.split(/[\\/]/).filter(Boolean).pop() ?? repoPath;
             api.setMainWindowTitle(`${repoName} - ${repoPath}`).catch(() => {
             });
@@ -579,9 +595,45 @@ export function App() {
         setRepoPath(path);
         pushRecentRepo(path);
         showToast("Repository initialised", "success");
-        appendResultLog("success", result.message, result.backendUsed);
+        appendResultLog("success", result.message, result.backendUsed, path);
         return true;
     }, [pushRecentRepo, showToast]);
+
+    const shouldOpenRepoInNewWindow = useCallback(async (path: string): Promise<boolean> => {
+        let behaviour: RepoOpenBehaviour = "Ask";
+        try {
+            behaviour = (await api.getSettings()).repoOpenBehaviour ?? "Ask";
+        } catch {
+            behaviour = "Ask";
+        }
+
+        if (behaviour === "NewWindow") {
+            return true;
+        }
+        if (behaviour === "ExistingWindow") {
+            return false;
+        }
+
+        return ask(
+            `Open "${path.split(/[\\/]/).filter(Boolean).pop() ?? path}" in a new Gitmun window?`,
+            {title: "Open Repository", kind: "info", okLabel: "New Window", cancelLabel: "This Window"},
+        );
+    }, []);
+
+    const openRepoPath = useCallback(async (path: string) => {
+        try {
+            await api.validateRepoPath(path);
+            if (await shouldOpenRepoInNewWindow(path)) {
+                await api.openRepoInNewWindow(path);
+                return;
+            }
+            setRepoPath(path);
+            pushRecentRepo(path);
+        } catch (e) {
+            if (await maybeInitialiseRepo(path, e)) return;
+            showToast(String(e), "error");
+        }
+    }, [maybeInitialiseRepo, pushRecentRepo, shouldOpenRepoInNewWindow, showToast]);
 
     const handleInitRepoClick = useCallback(async () => {
         try {
@@ -591,14 +643,18 @@ export function App() {
             }
             const result = await api.initRepo(selected);
             await api.validateRepoPath(selected);
-            setRepoPath(selected);
-            pushRecentRepo(selected);
+            if (await shouldOpenRepoInNewWindow(selected)) {
+                await api.openRepoInNewWindow(selected);
+            } else {
+                setRepoPath(selected);
+                pushRecentRepo(selected);
+            }
             showToast("Repository initialised", "success");
-            appendResultLog("success", result.message, result.backendUsed);
+            appendResultLog("success", result.message, result.backendUsed, selected);
         } catch (e) {
             showToast(String(e), "error");
         }
-    }, [pushRecentRepo, showToast]);
+    }, [pushRecentRepo, shouldOpenRepoInNewWindow, showToast]);
 
     const handleOpenExistingClick = useCallback(async () => {
         let selected: string | null = null;
@@ -608,25 +664,16 @@ export function App() {
                 return;
             }
             selected = picked;
-            await api.validateRepoPath(selected);
-            setRepoPath(selected);
-            pushRecentRepo(selected);
+            await openRepoPath(selected);
         } catch (e) {
             if (selected && await maybeInitialiseRepo(selected, e)) return;
             showToast(String(e), "error");
         }
-    }, [maybeInitialiseRepo, pushRecentRepo, showToast]);
+    }, [maybeInitialiseRepo, openRepoPath, showToast]);
 
     const handleRepoSelect = useCallback(async (path: string) => {
-        try {
-            await api.validateRepoPath(path);
-            setRepoPath(path);
-            pushRecentRepo(path);
-        } catch (e) {
-            if (await maybeInitialiseRepo(path, e)) return;
-            showToast(String(e), "error");
-        }
-    }, [maybeInitialiseRepo, pushRecentRepo, showToast]);
+        await openRepoPath(path);
+    }, [openRepoPath]);
 
     const isNative = true;
     const winRadius = 0;

--- a/src/components/clone/CloneWindow.tsx
+++ b/src/components/clone/CloneWindow.tsx
@@ -1,6 +1,6 @@
 import React, { useState, useEffect, useCallback, useRef } from "react";
 import { invoke, Channel } from "@tauri-apps/api/core";
-import { emit } from "@tauri-apps/api/event";
+import { emit, listen } from "@tauri-apps/api/event";
 import { open } from "@tauri-apps/plugin-dialog";
 import { platform } from "@tauri-apps/plugin-os";
 import { getCurrentWindow } from "@tauri-apps/api/window";
@@ -8,6 +8,7 @@ import type { OperationResult, Settings, ThemeMode } from "../../types";
 import { CloseIcon, FolderIcon } from "../icons";
 import { appendResultLog } from "../../utils/resultLog";
 import { getCloneRepoUrlError } from "../../utils/gitInputValidation";
+import { takePendingCloneDestination } from "../../api/commands";
 import "./CloneWindow.css";
 
 const CLONE_BASE_KEY = "gitmun.cloneBaseDir";
@@ -79,9 +80,8 @@ export function CloneWindow() {
         document.documentElement.dataset.theme = await resolveTheme(settings.themeMode);
 
         // Initialise destination: pending shell destination > last-used dir > settings default > OS default.
-        const pendingDestination = localStorage.getItem("gitmun.pendingCloneDestination");
+        const pendingDestination = await takePendingCloneDestination();
         if (pendingDestination) {
-          localStorage.removeItem("gitmun.pendingCloneDestination");
           baseDirRef.current = pendingDestination;
           setDestination(pendingDestination);
           isAutoRef.current = false;
@@ -103,6 +103,25 @@ export function CloneWindow() {
         setStatus(`Failed to load settings: ${e}`);
       }
     })();
+  }, []);
+
+  useEffect(() => {
+    let cancelled = false;
+    let unlisten: (() => void) | null = null;
+    (async () => {
+      const fn = await listen<string>("clone-destination-updated", (event) => {
+        const path = event.payload;
+        if (!path) return;
+        baseDirRef.current = path;
+        setDestination(path);
+        isAutoRef.current = false;
+      });
+      if (cancelled) fn(); else unlisten = fn;
+    })();
+    return () => {
+      cancelled = true;
+      unlisten?.();
+    };
   }, []);
 
   useEffect(() => {
@@ -208,7 +227,7 @@ export function CloneWindow() {
 
       const outputDetails = result.output ? ` (${result.output})` : "";
       setStatus(`${result.message}${outputDetails}`);
-      appendResultLog("success", result.message, result.backendUsed);
+      appendResultLog("success", result.message, result.backendUsed, result.repoPath ?? destination);
       await getCurrentWindow().close();
     } catch (e) {
       const msg = String(e);
@@ -216,7 +235,7 @@ export function CloneWindow() {
         setStatus("Clone cancelled.");
       } else {
         setStatus(`Clone failed: ${msg}`);
-        appendResultLog("error", `Clone failed: ${msg}`, "unknown");
+        appendResultLog("error", `Clone failed: ${msg}`, "unknown", destination);
       }
     } finally {
       setCloning(false);

--- a/src/components/resultlog/ResultLogWindow.css
+++ b/src/components/resultlog/ResultLogWindow.css
@@ -187,6 +187,11 @@
 .result-log__console-backend--gix-cli-fallback { color: var(--yellow); }
 .result-log__console-backend--unknown { color: var(--text-muted); }
 
+.result-log__console-repo {
+  margin-left: 6px;
+  color: var(--text-muted);
+}
+
 .result-log__dot {
   width: 8px;
   height: 8px;
@@ -226,6 +231,15 @@
   border: 1px solid var(--border-subtle);
   border-radius: 999px;
   padding: 1px 6px;
+}
+
+.result-log__repo {
+  max-width: 220px;
+  overflow: hidden;
+  text-overflow: ellipsis;
+  white-space: nowrap;
+  font-size: 11px;
+  color: var(--text-secondary);
 }
 
 .result-log__backend--gix {

--- a/src/components/resultlog/ResultLogWindow.tsx
+++ b/src/components/resultlog/ResultLogWindow.tsx
@@ -18,6 +18,11 @@ async function resolveTheme(mode: ThemeMode): Promise<"light" | "dark"> {
   }
 }
 
+function repoLabel(repoPath?: string | null): string | null {
+  if (!repoPath) return null;
+  return repoPath.split(/[\\/]/).filter(Boolean).pop() ?? repoPath;
+}
+
 export function ResultLogWindow() {
   const [entries, setEntries] = useState<ResultLogEntry[]>(() => getResultLogEntries());
   const [filter, setFilter] = useState<"all" | "success" | "error" | "info">("all");
@@ -117,6 +122,7 @@ export function ResultLogWindow() {
                 >
                   [{entry.backend}]
                 </span>
+                {entry.repoPath && <span className="result-log__console-repo">[{repoLabel(entry.repoPath)}]</span>}
                 <span className="result-log__console-message"> {entry.message}</span>
               </div>
             ))}
@@ -128,6 +134,7 @@ export function ResultLogWindow() {
               <div className="result-log__message">{entry.message}</div>
               <div className="result-log__meta">
                 <span className="result-log__time">{new Date(entry.ts).toLocaleString()}</span>
+                {entry.repoPath && <span className="result-log__repo" title={entry.repoPath}>{repoLabel(entry.repoPath)}</span>}
                 <span
                   className={`result-log__backend result-log__backend--${
                     entry.backend === "gix+cli-fallback" ? "gix-cli-fallback" : entry.backend

--- a/src/components/settings/SettingsWindow.tsx
+++ b/src/components/settings/SettingsWindow.tsx
@@ -10,6 +10,7 @@ import type {
     CommitDateMode,
     ExternalDiffTool,
     LinuxGraphicsMode,
+    RepoOpenBehaviour,
     Settings,
     ThemeMode
 } from "../../types";
@@ -94,6 +95,7 @@ export function SettingsWindow() {
     const [autoInstallUpdates, setAutoInstallUpdates] = useState(false);
     const [updateEndpoint, setUpdateEndpointState] = useState(DEFAULT_UPDATE_ENDPOINT);
     const [linuxGraphicsMode, setLinuxGraphicsMode] = useState<LinuxGraphicsMode>("Auto");
+    const [repoOpenBehaviour, setRepoOpenBehaviour] = useState<RepoOpenBehaviour>("Ask");
     const [isLinux, setIsLinux] = useState(false);
     const [isWindows, setIsWindows] = useState(false);
     const [updaterSupported, setUpdaterSupported] = useState(false);
@@ -151,6 +153,7 @@ export function SettingsWindow() {
                 setAutoInstallUpdates(settings.autoInstallUpdates ?? false);
                 setUpdateEndpointState(settings.updateEndpoint ?? DEFAULT_UPDATE_ENDPOINT);
                 setLinuxGraphicsMode(settings.linuxGraphicsMode ?? "Auto");
+                setRepoOpenBehaviour(settings.repoOpenBehaviour ?? "Ask");
                 document.documentElement.dataset.theme = await resolveTheme(settings.themeMode);
 
                 const cfgPath = await invoke<string | null>("get_config_file_path");
@@ -221,6 +224,7 @@ export function SettingsWindow() {
             await invoke("set_auto_install_updates", {autoInstallUpdates});
             await setUpdateEndpoint(updateEndpoint);
             if (isLinux) await invoke("set_linux_graphics_mode", {mode: linuxGraphicsMode});
+            await invoke("set_repo_open_behaviour", {repoOpenBehaviour});
             const settings = await invoke<Settings>("get_settings");
 
             localStorage.setItem(BACKEND_MODE_KEY, settings.backendMode);
@@ -258,6 +262,7 @@ export function SettingsWindow() {
         isLinux,
         isWindows,
         linuxGraphicsMode,
+        repoOpenBehaviour,
         externalDiffToolPath,
     ]);
 
@@ -342,6 +347,23 @@ export function SettingsWindow() {
                             Build version: <code>{buildVersion}</code>
                         </div>
                     )}
+
+                    <div className="settings-window__row">
+                        <label className="settings-window__label">Open repositories</label>
+                        <select
+                            className="settings-window__select"
+                            value={repoOpenBehaviour}
+                            onChange={e => setRepoOpenBehaviour(e.target.value as RepoOpenBehaviour)}
+                        >
+                            <option value="Ask">Ask each time (default)</option>
+                            <option value="ExistingWindow">Reuse this window</option>
+                            <option value="NewWindow">Always open a new window</option>
+                        </select>
+                        <div className="settings-window__section-note">
+                            Controls in-app repository opens, including recent repositories. Shell and file manager
+                            launches always open a new window.
+                        </div>
+                    </div>
 
                     {updaterSupported ? (
                         <div className="settings-window__row">

--- a/src/types.ts
+++ b/src/types.ts
@@ -6,6 +6,7 @@ export type CommitDateMode = "AuthorDate" | "CommitterDate";
 export type CommitLogScope = "currentCheckout" | "allRefs";
 export type CommitPrimaryAction = "commit" | "commitAndPush";
 export type LinuxGraphicsMode = "Auto" | "Safe" | "Native";
+export type RepoOpenBehaviour = "Ask" | "ExistingWindow" | "NewWindow";
 
 export type Settings = {
     backendMode: BackendMode;
@@ -25,6 +26,7 @@ export type Settings = {
     autoInstallUpdates: boolean;
     updateEndpoint: string;
     linuxGraphicsMode: LinuxGraphicsMode;
+    repoOpenBehaviour: RepoOpenBehaviour;
 };
 
 export type AvailableUpdate = {

--- a/src/utils/resultLog.ts
+++ b/src/utils/resultLog.ts
@@ -6,10 +6,16 @@ export type ResultLogEntry = {
   level: ResultLogLevel;
   message: string;
   backend: "gix" | "git-cli" | "gix+cli-fallback" | "unknown";
+  repoPath?: string | null;
 };
 
 export const RESULT_LOG_STORAGE_KEY = "gitmun.resultLogEntries";
 const RESULT_LOG_LIMIT = 500;
+let currentRepoPath: string | null = null;
+
+export function setResultLogRepoPath(repoPath: string | null) {
+  currentRepoPath = repoPath;
+}
 
 export function getResultLogEntries(): ResultLogEntry[] {
   try {
@@ -27,6 +33,7 @@ export function getResultLogEntries(): ResultLogEntry[] {
         backend: entry.backend === "gix" || entry.backend === "git-cli" || entry.backend === "gix+cli-fallback"
           ? entry.backend
           : "unknown",
+        repoPath: entry.repoPath ?? null,
       }));
   } catch {
     return [];
@@ -37,6 +44,7 @@ export function appendResultLog(
   level: ResultLogLevel,
   message: string,
   backend: ResultLogEntry["backend"] = "unknown",
+  repoPath?: string | null,
 ) {
   const entry: ResultLogEntry = {
     id: `${Date.now()}-${Math.random().toString(36).slice(2, 8)}`,
@@ -44,6 +52,7 @@ export function appendResultLog(
     level,
     message,
     backend,
+    repoPath: repoPath ?? currentRepoPath,
   };
 
   const next = [entry, ...getResultLogEntries()].slice(0, RESULT_LOG_LIMIT);


### PR DESCRIPTION
Add support for multiple instances (or windows). You can now can have multiple instances running for all the different projects you're working on. When you open, clone, or init a repo you will now be asked whether to open in a new window or the current window. You can set whether you want it to open in a new window or the existing window (basically the prev behaviour if enabled). CLI calls will always open in a new window.