### PR TITLE
test: set core.autocrlf=false in init_repo to fix CRLF mismatch

### DIFF
--- a/src-tauri/tests/git.rs
+++ b/src-tauri/tests/git.rs
@@ -21,6 +21,7 @@ fn init_repo() -> TempDir {
     git(path, &["config", "user.email", "test@gitmun.test"]);
     git(path, &["config", "user.name", "Gitmun Test"]);
     git(path, &["config", "commit.gpgsign", "false"]);
+    git(path, &["config", "core.autocrlf", "false"]);
     // Initial empty commit so HEAD exists
     git(path, &["commit", "--allow-empty", "-m", "init"]);
     dir


### PR DESCRIPTION
### Motivation
- Prevent Git on Windows from normalizing LF to CRLF during test patch application by disabling `core.autocrlf` for repositories created by the test helper.

### Description
- Add `git(path, &["config", "core.autocrlf", "false"]);` to `init_repo()` in `src-tauri/tests/git.rs` so test repos keep Unix line endings.

### Testing
- Ran `cargo test --manifest-path src-tauri/Cargo.toml import_patch_applies_to_working_tree`, which was blocked by a missing system dependency (`glib-2.0` / pkg-config) and could not complete. 
- Ran `cargo fmt --manifest-path src-tauri/Cargo.toml --check`, which reported unrelated rustfmt diffs in the repository. 
- Ran `git diff --check`, which reported no issues.

------
[Codex Task](https://chatgpt.com/codex/cloud/tasks/task_e_6a186061a48c832d83201099e7b34698)